### PR TITLE
Investigate missing storybook stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,8 @@
 import type { StorybookConfig } from '@storybook/nextjs'
 
-module.exports = {
-  stories: ['../!(node_modules)/**/*.stories.@(js|jsx|ts|tsx)'],
+const config: StorybookConfig = {
+  // SB9+ uses fast-glob; avoid extglob patterns here
+  stories: ['../**/*.stories.@(js|jsx|ts|tsx)'],
   staticDirs: ['../public'],
   addons: [
     '@storybook/addon-links',
@@ -25,4 +26,6 @@ module.exports = {
     })
     return config
   }
-} satisfies StorybookConfig
+}
+
+export default config


### PR DESCRIPTION
Update Storybook config to ESM and fix stories glob pattern for Storybook 9 compatibility.

The previous `stories` glob pattern used an extglob (`!(node_modules)`) which is not supported by Storybook 9's `fast-glob` library, causing no stories to be discovered. The updated pattern is compatible, and Storybook 9 automatically ignores `node_modules`. The configuration was also updated to an ESM default export, which is the preferred style for Storybook 9.

---
<a href="https://cursor.com/background-agent?bcId=bc-20414a96-8d50-4ac5-b488-3b3d5f94e2d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-20414a96-8d50-4ac5-b488-3b3d5f94e2d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

